### PR TITLE
CI: prevent publish-unit-test-result-action 403 on PR comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,4 @@ jobs:
         files: '**/test-results.trx'
         check_name: Unit Test Results
         comment_title: Test Results
+        comment_mode: off


### PR DESCRIPTION
## Summary
Fixes CI failures from `EnricoMi/publish-unit-test-result-action@v2` caused by insufficient token permission to create PR comments.

## Change
- In `.github/workflows/test.yml`, set:
  - `comment_mode: off`

This keeps test result checks/job summary publishing while disabling PR issue comments that were failing with:
`Resource not accessible by integration (403)`

## Why
The action successfully created checks and summary, but failed at `POST /issues/{id}/comments` in restricted contexts, which caused noisy failures.

## Validation
- Workflow config updated on a clean branch from current `main`
- Branch pushed: `ci-fix-publish-test-results-403`