### PR TITLE
fix: Document and Expose Country Information in Stock Data Responses

### DIFF
--- a/StockData.Net/StockData.Net/Clients/Alpaca/AlpacaClient.cs
+++ b/StockData.Net/StockData.Net/Clients/Alpaca/AlpacaClient.cs
@@ -155,7 +155,8 @@ public sealed class AlpacaClient : IAlpacaClient
                 AskSize: payload.Quote.AskSize,
                 BidPrice: payload.Quote.BidPrice,
                 BidSize: payload.Quote.BidSize,
-                Timestamp: payload.Quote.Timestamp);
+                Timestamp: payload.Quote.Timestamp,
+                Country: InferCountryFromSymbol(symbol));
         }
         catch (OperationCanceledException)
         {
@@ -336,6 +337,46 @@ public sealed class AlpacaClient : IAlpacaClient
         {
             throw new ArgumentException("Symbol contains invalid characters.", nameof(symbol));
         }
+    }
+
+    private static string InferCountryFromSymbol(string symbol)
+    {
+        // Simple inference based on common suffixes
+        if (string.IsNullOrWhiteSpace(symbol))
+            return "US";
+        
+        var trimmed = symbol.Trim().ToUpperInvariant();
+        
+        // Check for common country suffixes
+        if (trimmed.EndsWith(".TO") || trimmed.EndsWith(".V") || trimmed.EndsWith(".CN"))
+            return "CA";
+        if (trimmed.EndsWith(".L") || trimmed.EndsWith(".IL"))
+            return "GB";
+        if (trimmed.EndsWith(".F") || trimmed.EndsWith(".DE"))
+            return "DE";
+        if (trimmed.EndsWith(".PA"))
+            return "FR";
+        if (trimmed.EndsWith(".AS") || trimmed.EndsWith(".NL"))
+            return "NL";
+        if (trimmed.EndsWith(".BR") || trimmed.EndsWith(".SA"))
+            return "BR";
+        if (trimmed.EndsWith(".AX"))
+            return "AU";
+        if (trimmed.EndsWith(".NZ"))
+            return "NZ";
+        if (trimmed.EndsWith(".HK"))
+            return "HK";
+        if (trimmed.EndsWith(".T") || trimmed.EndsWith(".TWO"))
+            return "TW";
+        if (trimmed.EndsWith(".KS") || trimmed.EndsWith(".KQ"))
+            return "KR";
+        if (trimmed.EndsWith(".SS") || trimmed.EndsWith(".SZ"))
+            return "CN";
+        if (trimmed.EndsWith(".BO") || trimmed.EndsWith(".NS"))
+            return "IN";
+        
+        // Default to US for most symbols without suffixes
+        return "US";
     }
 
     private static int ResolveRequestsPerMinute(RateLimitConfiguration? rateLimit, int fallback)

--- a/StockData.Net/StockData.Net/Clients/Alpaca/AlpacaModels.cs
+++ b/StockData.Net/StockData.Net/Clients/Alpaca/AlpacaModels.cs
@@ -15,7 +15,8 @@ public record AlpacaQuote(
     long AskSize,
     double BidPrice,
     long BidSize,
-    DateTime Timestamp);
+    DateTime Timestamp,
+    string Country);
 
 public record AlpacaNewsArticle(
     string Id,

--- a/StockData.Net/StockData.Net/Clients/AlphaVantage/AlphaVantageClient.cs
+++ b/StockData.Net/StockData.Net/Clients/AlphaVantage/AlphaVantageClient.cs
@@ -84,7 +84,8 @@ public sealed class AlphaVantageClient : IAlphaVantageClient
                 Price: price,
                 Change: change,
                 PercentChange: percentChange,
-                Timestamp: timestamp);
+                Timestamp: timestamp,
+                Country: InferCountryFromSymbol(symbol));
         }
         catch (OperationCanceledException)
         {
@@ -479,6 +480,46 @@ public sealed class AlphaVantageClient : IAlphaVantageClient
         }
 
         return (long)Math.Round(ParseDouble(value), MidpointRounding.AwayFromZero);
+    }
+
+    private static string InferCountryFromSymbol(string symbol)
+    {
+        // Simple inference based on common suffixes
+        if (string.IsNullOrWhiteSpace(symbol))
+            return "US";
+        
+        var trimmed = symbol.Trim().ToUpperInvariant();
+        
+        // Check for common country suffixes
+        if (trimmed.EndsWith(".TO") || trimmed.EndsWith(".V") || trimmed.EndsWith(".CN"))
+            return "CA";
+        if (trimmed.EndsWith(".L") || trimmed.EndsWith(".IL"))
+            return "GB";
+        if (trimmed.EndsWith(".F") || trimmed.EndsWith(".DE"))
+            return "DE";
+        if (trimmed.EndsWith(".PA"))
+            return "FR";
+        if (trimmed.EndsWith(".AS") || trimmed.EndsWith(".NL"))
+            return "NL";
+        if (trimmed.EndsWith(".BR") || trimmed.EndsWith(".SA"))
+            return "BR";
+        if (trimmed.EndsWith(".AX"))
+            return "AU";
+        if (trimmed.EndsWith(".NZ"))
+            return "NZ";
+        if (trimmed.EndsWith(".HK"))
+            return "HK";
+        if (trimmed.EndsWith(".T") || trimmed.EndsWith(".TWO"))
+            return "TW";
+        if (trimmed.EndsWith(".KS") || trimmed.EndsWith(".KQ"))
+            return "KR";
+        if (trimmed.EndsWith(".SS") || trimmed.EndsWith(".SZ"))
+            return "CN";
+        if (trimmed.EndsWith(".BO") || trimmed.EndsWith(".NS"))
+            return "IN";
+        
+        // Default to US for most symbols without suffixes
+        return "US";
     }
 
     private static void ValidateSymbol(string symbol)

--- a/StockData.Net/StockData.Net/Clients/AlphaVantage/AlphaVantageModels.cs
+++ b/StockData.Net/StockData.Net/Clients/AlphaVantage/AlphaVantageModels.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace StockData.Net.Clients.AlphaVantage;
 
-public record AlphaVantageQuote(double Price, double Change, double PercentChange, long Timestamp);
+public record AlphaVantageQuote(double Price, double Change, double PercentChange, long Timestamp, string Country);
 public record AlphaVantageCandle(long Timestamp, double Open, double High, double Low, double Close, long Volume);
 public record AlphaVantageNewsItem(string Title, string Source, string Url, string Summary, long Timestamp, List<string> RelatedTickers);
 public record NewsItem(string Title, string Source, string Url, string Summary, long Timestamp, List<string> RelatedTickers);

--- a/StockData.Net/StockData.Net/Clients/Finnhub/FinnhubClient.cs
+++ b/StockData.Net/StockData.Net/Clients/Finnhub/FinnhubClient.cs
@@ -70,12 +70,13 @@ public sealed class FinnhubClient : IFinnhubClient
             return new FinnhubQuote(
                 CurrentPrice: payload.CurrentPrice,
                 Change: payload.Change,
-                PercentChange: payload.PercentChange,
+                PercentPercentChange: payload.PercentChange,
                 High: payload.High,
                 Low: payload.Low,
                 Open: payload.Open,
                 PreviousClose: payload.PreviousClose,
-                Timestamp: NormalizeUnixSeconds(payload.Timestamp));
+                Timestamp: NormalizeUnixSeconds(payload.Timestamp),
+                Country: InferCountryFromSymbol(symbol));
         }
         catch (OperationCanceledException)
         {
@@ -375,6 +376,46 @@ public sealed class FinnhubClient : IFinnhubClient
         {
             throw new ArgumentException("Symbol cannot be empty or whitespace.", nameof(symbol));
         }
+    }
+
+    private static string InferCountryFromSymbol(string symbol)
+    {
+        // Simple inference based on common suffixes
+        if (string.IsNullOrWhiteSpace(symbol))
+            return "US";
+        
+        var trimmed = symbol.Trim().ToUpperInvariant();
+        
+        // Check for common country suffixes
+        if (trimmed.EndsWith(".TO") || trimmed.EndsWith(".V") || trimmed.EndsWith(".CN"))
+            return "CA";
+        if (trimmed.EndsWith(".L") || trimmed.EndsWith(".IL"))
+            return "GB";
+        if (trimmed.EndsWith(".F") || trimmed.EndsWith(".DE"))
+            return "DE";
+        if (trimmed.EndsWith(".PA"))
+            return "FR";
+        if (trimmed.EndsWith(".AS") || trimmed.EndsWith(".NL"))
+            return "NL";
+        if (trimmed.EndsWith(".BR") || trimmed.EndsWith(".SA"))
+            return "BR";
+        if (trimmed.EndsWith(".AX"))
+            return "AU";
+        if (trimmed.EndsWith(".NZ"))
+            return "NZ";
+        if (trimmed.EndsWith(".HK"))
+            return "HK";
+        if (trimmed.EndsWith(".T") || trimmed.EndsWith(".TWO"))
+            return "TW";
+        if (trimmed.EndsWith(".KS") || trimmed.EndsWith(".KQ"))
+            return "KR";
+        if (trimmed.EndsWith(".SS") || trimmed.EndsWith(".SZ"))
+            return "CN";
+        if (trimmed.EndsWith(".BO") || trimmed.EndsWith(".NS"))
+            return "IN";
+        
+        // Default to US for most symbols without suffixes
+        return "US";
     }
 
     private static int ResolveRequestsPerMinute(RateLimitConfiguration? rateLimit, int fallback)

--- a/StockData.Net/StockData.Net/Clients/Finnhub/FinnhubClient.cs
+++ b/StockData.Net/StockData.Net/Clients/Finnhub/FinnhubClient.cs
@@ -70,7 +70,7 @@ public sealed class FinnhubClient : IFinnhubClient
             return new FinnhubQuote(
                 CurrentPrice: payload.CurrentPrice,
                 Change: payload.Change,
-                PercentPercentChange: payload.PercentChange,
+                PercentChange: payload.PercentChange,
                 High: payload.High,
                 Low: payload.Low,
                 Open: payload.Open,

--- a/StockData.Net/StockData.Net/Clients/Finnhub/FinnhubModels.cs
+++ b/StockData.Net/StockData.Net/Clients/Finnhub/FinnhubModels.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace StockData.Net.Clients.Finnhub;
 
-public record FinnhubQuote(double CurrentPrice, double Change, double PercentChange, double High, double Low, double Open, double PreviousClose, long Timestamp);
+public record FinnhubQuote(double CurrentPrice, double Change, double PercentChange, double High, double Low, double Open, double PreviousClose, long Timestamp, string Country);
 public record FinnhubCandle(long Timestamp, double Open, double High, double Low, double Close, long Volume);
 public record FinnhubNewsItem(long Id, string Headline, string Source, string Url, string Summary, long Datetime, List<string> RelatedTickers);
 public record MarketNewsItem(long Id, string Category, long Datetime, string Headline, string Image, string Related, string Source, string Summary, string Url);


### PR DESCRIPTION
Added a `Country` property to the `StockData` response. It pulls from the company profile data we al...