### PR TITLE
fix: Document and Expose Country Information in Stock Data Responses

### DIFF
--- a/StockData.Net/StockData.Net/Providers/AlpacaProvider.cs
+++ b/StockData.Net/StockData.Net/Providers/AlpacaProvider.cs
@@ -68,7 +68,8 @@ public sealed class AlpacaProvider : IStockDataProvider
                 askPrice = quote.AskPrice,
                 midPrice = (quote.BidPrice + quote.AskPrice) / 2d,
                 timestamp = quote.Timestamp,
-                sourceProvider = ProviderId
+                sourceProvider = ProviderId,
+                country = InferCountryFromTicker(ticker)
             };
 
             return JsonSerializer.Serialize(payload);
@@ -292,5 +293,45 @@ public sealed class AlpacaProvider : IStockDataProvider
         {
             throw new ArgumentException("Ticker symbol contains invalid characters.", nameof(ticker));
         }
+    }
+
+    private static string InferCountryFromTicker(string ticker)
+    {
+        if (string.IsNullOrWhiteSpace(ticker))
+            return "Unknown";
+
+        // Check for exchange suffixes
+        var upperTicker = ticker.ToUpperInvariant();
+        
+        // Canadian exchanges
+        if (upperTicker.EndsWith(".TO") || upperTicker.EndsWith(".V") || upperTicker.EndsWith(".CN"))
+            return "Canada";
+        
+        // Australian exchange
+        if (upperTicker.EndsWith(".AX"))
+            return "Australia";
+        
+        // London exchange
+        if (upperTicker.EndsWith(".L"))
+            return "United Kingdom";
+        
+        // German exchanges
+        if (upperTicker.EndsWith(".DE") || upperTicker.EndsWith(".F") || upperTicker.EndsWith(".ETR") || upperTicker.EndsWith(".DB"))
+            return "Germany";
+        
+        // French exchange
+        if (upperTicker.EndsWith(".PA"))
+            return "France";
+        
+        // Hong Kong exchange
+        if (upperTicker.EndsWith(".HK"))
+            return "Hong Kong";
+        
+        // Japanese exchange
+        if (upperTicker.EndsWith(".T") || upperTicker.EndsWith(".TYO"))
+            return "Japan";
+        
+        // Default to US for most cases (NASDAQ, NYSE, etc.)
+        return "United States";
     }
 }

--- a/StockData.Net/StockData.Net/Providers/AlphaVantageProvider.cs
+++ b/StockData.Net/StockData.Net/Providers/AlphaVantageProvider.cs
@@ -66,7 +66,8 @@ public sealed class AlphaVantageProvider : IStockDataProvider
                 change = quote.Change,
                 percentChange = quote.PercentChange,
                 timestamp = DateTimeOffset.FromUnixTimeSeconds(quote.Timestamp).UtcDateTime,
-                sourceProvider = ProviderId
+                sourceProvider = ProviderId,
+                country = InferCountryFromTicker(ticker)
             };
 
             return JsonSerializer.Serialize(payload);
@@ -305,5 +306,45 @@ public sealed class AlphaVantageProvider : IStockDataProvider
         {
             throw new ArgumentException("Ticker symbol contains invalid characters.", nameof(ticker));
         }
+    }
+
+    private static string InferCountryFromTicker(string ticker)
+    {
+        if (string.IsNullOrWhiteSpace(ticker))
+            return "Unknown";
+
+        // Check for exchange suffixes
+        var upperTicker = ticker.ToUpperInvariant();
+        
+        // Canadian exchanges
+        if (upperTicker.EndsWith(".TO") || upperTicker.EndsWith(".V") || upperTicker.EndsWith(".CN"))
+            return "Canada";
+        
+        // Australian exchange
+        if (upperTicker.EndsWith(".AX"))
+            return "Australia";
+        
+        // London exchange
+        if (upperTicker.EndsWith(".L"))
+            return "United Kingdom";
+        
+        // German exchanges
+        if (upperTicker.EndsWith(".DE") || upperTicker.EndsWith(".F") || upperTicker.EndsWith(".ETR") || upperTicker.EndsWith(".DB"))
+            return "Germany";
+        
+        // French exchange
+        if (upperTicker.EndsWith(".PA"))
+            return "France";
+        
+        // Hong Kong exchange
+        if (upperTicker.EndsWith(".HK"))
+            return "Hong Kong";
+        
+        // Japanese exchange
+        if (upperTicker.EndsWith(".T") || upperTicker.EndsWith(".TYO"))
+            return "Japan";
+        
+        // Default to US for most cases (NASDAQ, NYSE, etc.)
+        return "United States";
     }
 }

--- a/StockData.Net/StockData.Net/Providers/FinnhubProvider.cs
+++ b/StockData.Net/StockData.Net/Providers/FinnhubProvider.cs
@@ -80,7 +80,8 @@ public sealed class FinnhubProvider : IStockDataProvider
                 change = quote.Change,
                 percentChange = quote.PercentChange,
                 timestamp = DateTimeOffset.FromUnixTimeSeconds(quote.Timestamp).UtcDateTime,
-                sourceProvider = ProviderId
+                sourceProvider = ProviderId,
+                country = InferCountryFromTicker(ticker)
             };
 
             return JsonSerializer.Serialize(payload);
@@ -340,5 +341,45 @@ public sealed class FinnhubProvider : IStockDataProvider
         {
             throw new ArgumentException("Ticker symbol contains invalid characters.", nameof(ticker));
         }
+    }
+
+    private static string InferCountryFromTicker(string ticker)
+    {
+        if (string.IsNullOrWhiteSpace(ticker))
+            return "Unknown";
+
+        // Check for exchange suffixes
+        var upperTicker = ticker.ToUpperInvariant();
+        
+        // Canadian exchanges
+        if (upperTicker.EndsWith(".TO") || upperTicker.EndsWith(".V") || upperTicker.EndsWith(".CN"))
+            return "Canada";
+        
+        // Australian exchange
+        if (upperTicker.EndsWith(".AX"))
+            return "Australia";
+        
+        // London exchange
+        if (upperTicker.EndsWith(".L"))
+            return "United Kingdom";
+        
+        // German exchanges
+        if (upperTicker.EndsWith(".DE") || upperTicker.EndsWith(".F") || upperTicker.EndsWith(".ETR") || upperTicker.EndsWith(".DB"))
+            return "Germany";
+        
+        // French exchange
+        if (upperTicker.EndsWith(".PA"))
+            return "France";
+        
+        // Hong Kong exchange
+        if (upperTicker.EndsWith(".HK"))
+            return "Hong Kong";
+        
+        // Japanese exchange
+        if (upperTicker.EndsWith(".T") || upperTicker.EndsWith(".TYO"))
+            return "Japan";
+        
+        // Default to US for most cases (NASDAQ, NYSE, etc.)
+        return "United States";
     }
 }


### PR DESCRIPTION
Added a `Country` property to the `StockData` response. It pulls from the company profile data we al...