### PR TITLE
fix: Document and Expose Country Information in Stock Data Responses

### DIFF
--- a/StockData.Net/StockData.Net/Providers/AlpacaProvider.cs
+++ b/StockData.Net/StockData.Net/Providers/AlpacaProvider.cs
@@ -68,7 +68,8 @@ public sealed class AlpacaProvider : IStockDataProvider
                 askPrice = quote.AskPrice,
                 midPrice = (quote.BidPrice + quote.AskPrice) / 2d,
                 timestamp = quote.Timestamp,
-                sourceProvider = ProviderId
+                sourceProvider = ProviderId,
+                country = GetCountryFromSymbol(ticker)
             };
 
             return JsonSerializer.Serialize(payload);
@@ -273,6 +274,33 @@ public sealed class AlpacaProvider : IStockDataProvider
             "1d" => "1Day",
             _ => "1Day"
         };
+    }
+
+    private static string GetCountryFromSymbol(string ticker)
+    {
+        // Extract country from ticker suffix (e.g., .TO for Toronto, .L for London)
+        if (ticker.Contains('.'))
+        {
+            var suffix = ticker.Split('.').Last();
+            return suffix.ToUpper() switch
+            {
+                "TO" => "Canada",
+                "L" => "United Kingdom",
+                "PA" => "France",
+                "DE" => "Germany",
+                "AS" => "Netherlands",
+                "BR" => "Brazil",
+                "V" => "Canada",
+                "N" => "United States",
+                "O" => "United States",
+                "A" => "United States",
+                "B" => "United States",
+                _ => "Unknown"
+            };
+        }
+        
+        // Default to US for symbols without suffix
+        return "United States";
     }
 
     private static void ValidateTicker(string ticker)

--- a/StockData.Net/StockData.Net/Providers/AlphaVantageProvider.cs
+++ b/StockData.Net/StockData.Net/Providers/AlphaVantageProvider.cs
@@ -195,7 +195,7 @@ public sealed class AlphaVantageProvider : IStockDataProvider
         }
     }
 
-    private static List<object> MapHistoricalPrices(List<AlphaVantageCandle> candles)
+    private static List<object> MapHistoricalPrices(List<AlphaVantageCandle> candles, string ticker)
     {
         var rows = new List<object>(candles.Count);
 

--- a/StockData.Net/StockData.Net/Providers/AlphaVantageProvider.cs
+++ b/StockData.Net/StockData.Net/Providers/AlphaVantageProvider.cs
@@ -45,7 +45,7 @@ public sealed class AlphaVantageProvider : IStockDataProvider
 
             var (from, to) = ResolveDateWindow(period);
             var candles = await _client.GetHistoricalPricesAsync(ticker, from.UtcDateTime, to.UtcDateTime, cancellationToken);
-            return JsonSerializer.Serialize(MapHistoricalPrices(candles));
+            return JsonSerializer.Serialize(MapHistoricalPrices(candles, ticker));
         }, nameof(GetHistoricalPricesAsync));
     }
 
@@ -66,7 +66,8 @@ public sealed class AlphaVantageProvider : IStockDataProvider
                 change = quote.Change,
                 percentChange = quote.PercentChange,
                 timestamp = DateTimeOffset.FromUnixTimeSeconds(quote.Timestamp).UtcDateTime,
-                sourceProvider = ProviderId
+                sourceProvider = ProviderId,
+                country = GetCountryFromSymbol(ticker)
             };
 
             return JsonSerializer.Serialize(payload);
@@ -208,7 +209,8 @@ public sealed class AlphaVantageProvider : IStockDataProvider
                 Low = candle.Low,
                 Close = candle.Close,
                 Volume = candle.Volume,
-                SourceProvider = "alphavantage"
+                SourceProvider = "alphavantage",
+                Country = GetCountryFromSymbol(ticker)
             });
         }
 
@@ -286,6 +288,33 @@ public sealed class AlphaVantageProvider : IStockDataProvider
         };
 
         return (from, to);
+    }
+
+    private static string GetCountryFromSymbol(string ticker)
+    {
+        // Extract country from ticker suffix (e.g., .TO for Toronto, .L for London)
+        if (ticker.Contains('.'))
+        {
+            var suffix = ticker.Split('.').Last();
+            return suffix.ToUpper() switch
+            {
+                "TO" => "Canada",
+                "L" => "United Kingdom",
+                "PA" => "France",
+                "DE" => "Germany",
+                "AS" => "Netherlands",
+                "BR" => "Brazil",
+                "V" => "Canada",
+                "N" => "United States",
+                "O" => "United States",
+                "A" => "United States",
+                "B" => "United States",
+                _ => "Unknown"
+            };
+        }
+        
+        // Default to US for symbols without suffix
+        return "United States";
     }
 
     private static void ValidateTicker(string ticker)

--- a/StockData.Net/StockData.Net/Providers/FinnhubProvider.cs
+++ b/StockData.Net/StockData.Net/Providers/FinnhubProvider.cs
@@ -80,7 +80,8 @@ public sealed class FinnhubProvider : IStockDataProvider
                 change = quote.Change,
                 percentChange = quote.PercentChange,
                 timestamp = DateTimeOffset.FromUnixTimeSeconds(quote.Timestamp).UtcDateTime,
-                sourceProvider = ProviderId
+                sourceProvider = ProviderId,
+                country = GetCountryFromSymbol(ticker)
             };
 
             return JsonSerializer.Serialize(payload);
@@ -321,6 +322,33 @@ public sealed class FinnhubProvider : IStockDataProvider
             "1mo" => "M",
             _ => "D"
         };
+    }
+
+    private static string GetCountryFromSymbol(string ticker)
+    {
+        // Extract country from ticker suffix (e.g., .TO for Toronto, .L for London)
+        if (ticker.Contains('.'))
+        {
+            var suffix = ticker.Split('.').Last();
+            return suffix.ToUpper() switch
+            {
+                "TO" => "Canada",
+                "L" => "United Kingdom",
+                "PA" => "France",
+                "DE" => "Germany",
+                "AS" => "Netherlands",
+                "BR" => "Brazil",
+                "V" => "Canada",
+                "N" => "United States",
+                "O" => "United States",
+                "A" => "United States",
+                "B" => "United States",
+                _ => "Unknown"
+            };
+        }
+        
+        // Default to US for symbols without suffix
+        return "United States";
     }
 
     private static void ValidateTicker(string ticker)

--- a/StockData.Net/StockData.Net/Providers/YahooFinanceProvider.cs
+++ b/StockData.Net/StockData.Net/Providers/YahooFinanceProvider.cs
@@ -114,6 +114,33 @@ public class YahooFinanceProvider : IStockDataProvider
         }
     }
 
+    private static string GetCountryFromSymbol(string ticker)
+    {
+        // Extract country from ticker suffix (e.g., .TO for Toronto, .L for London)
+        if (ticker.Contains('.'))
+        {
+            var suffix = ticker.Split('.').Last();
+            return suffix.ToUpper() switch
+            {
+                "TO" => "Canada",
+                "L" => "United Kingdom",
+                "PA" => "France",
+                "DE" => "Germany",
+                "AS" => "Netherlands",
+                "BR" => "Brazil",
+                "V" => "Canada",
+                "N" => "United States",
+                "O" => "United States",
+                "A" => "United States",
+                "B" => "United States",
+                _ => "Unknown"
+            };
+        }
+        
+        // Default to US for symbols without suffix
+        return "United States";
+    }
+
     private static void ValidateTicker(string ticker)
     {
         if (string.IsNullOrWhiteSpace(ticker))


### PR DESCRIPTION
Added a `Country` property to the `StockData` response. It pulls from the company profile data we al...