### PR TITLE
feat: smart country inference from ticker suffix (consolidates PRs #56–#61) [#50]

### DIFF
--- a/StockData.Net/StockData.Net/Providers/AlpacaProvider.cs
+++ b/StockData.Net/StockData.Net/Providers/AlpacaProvider.cs
@@ -48,7 +48,7 @@ public sealed class AlpacaProvider : IStockDataProvider
             var (from, to) = ResolveDateWindow(period);
             var timeframe = ResolveTimeframe(interval);
             var bars = await _client.GetHistoricalBarsAsync(ticker, from.UtcDateTime, to.UtcDateTime, timeframe, cancellationToken);
-            return JsonSerializer.Serialize(MapHistoricalPrices(bars));
+            return JsonSerializer.Serialize(MapHistoricalPrices(bars, ticker));
         }, nameof(GetHistoricalPricesAsync));
     }
 
@@ -69,7 +69,7 @@ public sealed class AlpacaProvider : IStockDataProvider
                 midPrice = (quote.BidPrice + quote.AskPrice) / 2d,
                 timestamp = quote.Timestamp,
                 sourceProvider = ProviderId,
-                Country = "US"
+                Country = InferCountryFromSymbol(ticker)
             };
 
             return JsonSerializer.Serialize(payload);
@@ -172,8 +172,9 @@ public sealed class AlpacaProvider : IStockDataProvider
         }
     }
 
-    private static List<object> MapHistoricalPrices(List<AlpacaBar> bars)
+    private static List<object> MapHistoricalPrices(List<AlpacaBar> bars, string ticker)
     {
+        var country = InferCountryFromSymbol(ticker);
         var rows = new List<object>(bars.Count);
         foreach (var bar in bars)
         {
@@ -186,7 +187,7 @@ public sealed class AlpacaProvider : IStockDataProvider
                 Close = bar.Close,
                 Volume = bar.Volume,
                 SourceProvider = "alpaca",
-                Country = "US"
+                Country = country
             });
         }
 
@@ -275,6 +276,43 @@ public sealed class AlpacaProvider : IStockDataProvider
             "1d" => "1Day",
             _ => "1Day"
         };
+    }
+
+    private static string InferCountryFromSymbol(string ticker)
+    {
+        if (string.IsNullOrWhiteSpace(ticker))
+        {
+            return "Unknown";
+        }
+
+        var cleanSymbol = ticker.StartsWith("^", StringComparison.Ordinal) ? ticker[1..] : ticker;
+
+        if (cleanSymbol.EndsWith(".TO", StringComparison.OrdinalIgnoreCase)) return "Canada";
+        if (cleanSymbol.EndsWith(".V", StringComparison.OrdinalIgnoreCase)) return "Canada";
+        if (cleanSymbol.EndsWith(".CN", StringComparison.OrdinalIgnoreCase)) return "Canada";
+        if (cleanSymbol.EndsWith(".L", StringComparison.OrdinalIgnoreCase)) return "United Kingdom";
+        if (cleanSymbol.EndsWith(".IL", StringComparison.OrdinalIgnoreCase)) return "United Kingdom";
+        if (cleanSymbol.EndsWith(".AX", StringComparison.OrdinalIgnoreCase)) return "Australia";
+        if (cleanSymbol.EndsWith(".NZ", StringComparison.OrdinalIgnoreCase)) return "New Zealand";
+        if (cleanSymbol.EndsWith(".DE", StringComparison.OrdinalIgnoreCase)) return "Germany";
+        if (cleanSymbol.EndsWith(".F", StringComparison.OrdinalIgnoreCase)) return "Germany";
+        if (cleanSymbol.EndsWith(".PA", StringComparison.OrdinalIgnoreCase)) return "France";
+        if (cleanSymbol.EndsWith(".AS", StringComparison.OrdinalIgnoreCase)) return "Netherlands";
+        if (cleanSymbol.EndsWith(".SW", StringComparison.OrdinalIgnoreCase)) return "Switzerland";
+        if (cleanSymbol.EndsWith(".BR", StringComparison.OrdinalIgnoreCase)) return "Brazil";
+        if (cleanSymbol.EndsWith(".SA", StringComparison.OrdinalIgnoreCase)) return "Brazil";
+        if (cleanSymbol.EndsWith(".HK", StringComparison.OrdinalIgnoreCase)) return "Hong Kong";
+        if (cleanSymbol.EndsWith(".T", StringComparison.OrdinalIgnoreCase)) return "Japan";
+        if (cleanSymbol.EndsWith(".KS", StringComparison.OrdinalIgnoreCase)) return "South Korea";
+        if (cleanSymbol.EndsWith(".KQ", StringComparison.OrdinalIgnoreCase)) return "South Korea";
+        if (cleanSymbol.EndsWith(".SS", StringComparison.OrdinalIgnoreCase)) return "China";
+        if (cleanSymbol.EndsWith(".SZ", StringComparison.OrdinalIgnoreCase)) return "China";
+        if (cleanSymbol.EndsWith(".BO", StringComparison.OrdinalIgnoreCase)) return "India";
+        if (cleanSymbol.EndsWith(".NS", StringComparison.OrdinalIgnoreCase)) return "India";
+
+        if (cleanSymbol.Contains('.')) return "International";
+
+        return "United States";
     }
 
     private static void ValidateTicker(string ticker)

--- a/StockData.Net/StockData.Net/Providers/AlphaVantageProvider.cs
+++ b/StockData.Net/StockData.Net/Providers/AlphaVantageProvider.cs
@@ -45,7 +45,7 @@ public sealed class AlphaVantageProvider : IStockDataProvider
 
             var (from, to) = ResolveDateWindow(period);
             var candles = await _client.GetHistoricalPricesAsync(ticker, from.UtcDateTime, to.UtcDateTime, cancellationToken);
-            return JsonSerializer.Serialize(MapHistoricalPrices(candles));
+            return JsonSerializer.Serialize(MapHistoricalPrices(candles, ticker));
         }, nameof(GetHistoricalPricesAsync));
     }
 
@@ -67,7 +67,7 @@ public sealed class AlphaVantageProvider : IStockDataProvider
                 percentChange = quote.PercentChange,
                 timestamp = DateTimeOffset.FromUnixTimeSeconds(quote.Timestamp).UtcDateTime,
                 sourceProvider = ProviderId,
-                Country = "US"
+                Country = InferCountryFromSymbol(ticker)
             };
 
             return JsonSerializer.Serialize(payload);
@@ -113,7 +113,7 @@ public sealed class AlphaVantageProvider : IStockDataProvider
                     item.Value,
                     item.ActionType,
                     sourceProvider = ProviderId,
-                    Country = "US"
+                    Country = InferCountryFromSymbol(ticker)
                 }),
                 stockSplits = actions.Splits.Select(item => new
                 {
@@ -123,10 +123,10 @@ public sealed class AlphaVantageProvider : IStockDataProvider
                     item.Denominator,
                     item.ActionType,
                     sourceProvider = ProviderId,
-                    Country = "US"
+                    Country = InferCountryFromSymbol(ticker)
                 }),
                 sourceProvider = ProviderId,
-                Country = "US"
+                Country = InferCountryFromSymbol(ticker)
             };
 
             return JsonSerializer.Serialize(payload);
@@ -198,8 +198,9 @@ public sealed class AlphaVantageProvider : IStockDataProvider
         }
     }
 
-    private static List<object> MapHistoricalPrices(List<AlphaVantageCandle> candles)
+    private static List<object> MapHistoricalPrices(List<AlphaVantageCandle> candles, string ticker)
     {
+        var country = InferCountryFromSymbol(ticker);
         var rows = new List<object>(candles.Count);
 
         foreach (var candle in candles)
@@ -213,7 +214,7 @@ public sealed class AlphaVantageProvider : IStockDataProvider
                 Close = candle.Close,
                 Volume = candle.Volume,
                 SourceProvider = "alphavantage",
-                Country = "US"
+                Country = country
             });
         }
 
@@ -310,5 +311,42 @@ public sealed class AlphaVantageProvider : IStockDataProvider
         {
             throw new ArgumentException("Ticker symbol contains invalid characters.", nameof(ticker));
         }
+    }
+
+    private static string InferCountryFromSymbol(string ticker)
+    {
+        if (string.IsNullOrWhiteSpace(ticker))
+        {
+            return "Unknown";
+        }
+
+        var cleanSymbol = ticker.StartsWith("^", StringComparison.Ordinal) ? ticker[1..] : ticker;
+
+        if (cleanSymbol.EndsWith(".TO", StringComparison.OrdinalIgnoreCase)) return "Canada";
+        if (cleanSymbol.EndsWith(".V", StringComparison.OrdinalIgnoreCase)) return "Canada";
+        if (cleanSymbol.EndsWith(".CN", StringComparison.OrdinalIgnoreCase)) return "Canada";
+        if (cleanSymbol.EndsWith(".L", StringComparison.OrdinalIgnoreCase)) return "United Kingdom";
+        if (cleanSymbol.EndsWith(".IL", StringComparison.OrdinalIgnoreCase)) return "United Kingdom";
+        if (cleanSymbol.EndsWith(".AX", StringComparison.OrdinalIgnoreCase)) return "Australia";
+        if (cleanSymbol.EndsWith(".NZ", StringComparison.OrdinalIgnoreCase)) return "New Zealand";
+        if (cleanSymbol.EndsWith(".DE", StringComparison.OrdinalIgnoreCase)) return "Germany";
+        if (cleanSymbol.EndsWith(".F", StringComparison.OrdinalIgnoreCase)) return "Germany";
+        if (cleanSymbol.EndsWith(".PA", StringComparison.OrdinalIgnoreCase)) return "France";
+        if (cleanSymbol.EndsWith(".AS", StringComparison.OrdinalIgnoreCase)) return "Netherlands";
+        if (cleanSymbol.EndsWith(".SW", StringComparison.OrdinalIgnoreCase)) return "Switzerland";
+        if (cleanSymbol.EndsWith(".BR", StringComparison.OrdinalIgnoreCase)) return "Brazil";
+        if (cleanSymbol.EndsWith(".SA", StringComparison.OrdinalIgnoreCase)) return "Brazil";
+        if (cleanSymbol.EndsWith(".HK", StringComparison.OrdinalIgnoreCase)) return "Hong Kong";
+        if (cleanSymbol.EndsWith(".T", StringComparison.OrdinalIgnoreCase)) return "Japan";
+        if (cleanSymbol.EndsWith(".KS", StringComparison.OrdinalIgnoreCase)) return "South Korea";
+        if (cleanSymbol.EndsWith(".KQ", StringComparison.OrdinalIgnoreCase)) return "South Korea";
+        if (cleanSymbol.EndsWith(".SS", StringComparison.OrdinalIgnoreCase)) return "China";
+        if (cleanSymbol.EndsWith(".SZ", StringComparison.OrdinalIgnoreCase)) return "China";
+        if (cleanSymbol.EndsWith(".BO", StringComparison.OrdinalIgnoreCase)) return "India";
+        if (cleanSymbol.EndsWith(".NS", StringComparison.OrdinalIgnoreCase)) return "India";
+
+        if (cleanSymbol.Contains('.')) return "International";
+
+        return "United States";
     }
 }

--- a/StockData.Net/StockData.Net/Providers/FinnhubProvider.cs
+++ b/StockData.Net/StockData.Net/Providers/FinnhubProvider.cs
@@ -55,7 +55,7 @@ public sealed class FinnhubProvider : IStockDataProvider
             var (from, to) = ResolveDateWindow(period);
             var resolution = ResolveResolution(interval);
             var candles = await _client.GetHistoricalPricesAsync(ticker, resolution, from.UtcDateTime, to.UtcDateTime, cancellationToken);
-            return JsonSerializer.Serialize(MapHistoricalPrices(candles));
+            return JsonSerializer.Serialize(MapHistoricalPrices(candles, ticker));
         }, nameof(GetHistoricalPricesAsync));
     }
 
@@ -81,7 +81,7 @@ public sealed class FinnhubProvider : IStockDataProvider
                 percentChange = quote.PercentChange,
                 timestamp = DateTimeOffset.FromUnixTimeSeconds(quote.Timestamp).UtcDateTime,
                 sourceProvider = ProviderId,
-                Country = "US"
+                Country = InferCountryFromSymbol(ticker)
             };
 
             return JsonSerializer.Serialize(payload);
@@ -166,7 +166,7 @@ public sealed class FinnhubProvider : IStockDataProvider
                 trend.Sell,
                 trend.StrongSell,
                 SourceProvider = ProviderId,
-                Country = "US"
+                Country = InferCountryFromSymbol(ticker)
             });
 
             return JsonSerializer.Serialize(payload);
@@ -215,8 +215,9 @@ public sealed class FinnhubProvider : IStockDataProvider
         }
     }
 
-    private static List<object> MapHistoricalPrices(List<FinnhubCandle> candles)
+    private static List<object> MapHistoricalPrices(List<FinnhubCandle> candles, string ticker)
     {
+        var country = InferCountryFromSymbol(ticker);
         var rows = new List<object>(candles.Count);
 
         foreach (var candle in candles)
@@ -230,7 +231,7 @@ public sealed class FinnhubProvider : IStockDataProvider
                 Close = candle.Close,
                 Volume = candle.Volume,
                 SourceProvider = "finnhub",
-                Country = "US"
+                Country = country
             });
         }
 
@@ -343,5 +344,42 @@ public sealed class FinnhubProvider : IStockDataProvider
         {
             throw new ArgumentException("Ticker symbol contains invalid characters.", nameof(ticker));
         }
+    }
+
+    private static string InferCountryFromSymbol(string ticker)
+    {
+        if (string.IsNullOrWhiteSpace(ticker))
+        {
+            return "Unknown";
+        }
+
+        var cleanSymbol = ticker.StartsWith("^", StringComparison.Ordinal) ? ticker[1..] : ticker;
+
+        if (cleanSymbol.EndsWith(".TO", StringComparison.OrdinalIgnoreCase)) return "Canada";
+        if (cleanSymbol.EndsWith(".V", StringComparison.OrdinalIgnoreCase)) return "Canada";
+        if (cleanSymbol.EndsWith(".CN", StringComparison.OrdinalIgnoreCase)) return "Canada";
+        if (cleanSymbol.EndsWith(".L", StringComparison.OrdinalIgnoreCase)) return "United Kingdom";
+        if (cleanSymbol.EndsWith(".IL", StringComparison.OrdinalIgnoreCase)) return "United Kingdom";
+        if (cleanSymbol.EndsWith(".AX", StringComparison.OrdinalIgnoreCase)) return "Australia";
+        if (cleanSymbol.EndsWith(".NZ", StringComparison.OrdinalIgnoreCase)) return "New Zealand";
+        if (cleanSymbol.EndsWith(".DE", StringComparison.OrdinalIgnoreCase)) return "Germany";
+        if (cleanSymbol.EndsWith(".F", StringComparison.OrdinalIgnoreCase)) return "Germany";
+        if (cleanSymbol.EndsWith(".PA", StringComparison.OrdinalIgnoreCase)) return "France";
+        if (cleanSymbol.EndsWith(".AS", StringComparison.OrdinalIgnoreCase)) return "Netherlands";
+        if (cleanSymbol.EndsWith(".SW", StringComparison.OrdinalIgnoreCase)) return "Switzerland";
+        if (cleanSymbol.EndsWith(".BR", StringComparison.OrdinalIgnoreCase)) return "Brazil";
+        if (cleanSymbol.EndsWith(".SA", StringComparison.OrdinalIgnoreCase)) return "Brazil";
+        if (cleanSymbol.EndsWith(".HK", StringComparison.OrdinalIgnoreCase)) return "Hong Kong";
+        if (cleanSymbol.EndsWith(".T", StringComparison.OrdinalIgnoreCase)) return "Japan";
+        if (cleanSymbol.EndsWith(".KS", StringComparison.OrdinalIgnoreCase)) return "South Korea";
+        if (cleanSymbol.EndsWith(".KQ", StringComparison.OrdinalIgnoreCase)) return "South Korea";
+        if (cleanSymbol.EndsWith(".SS", StringComparison.OrdinalIgnoreCase)) return "China";
+        if (cleanSymbol.EndsWith(".SZ", StringComparison.OrdinalIgnoreCase)) return "China";
+        if (cleanSymbol.EndsWith(".BO", StringComparison.OrdinalIgnoreCase)) return "India";
+        if (cleanSymbol.EndsWith(".NS", StringComparison.OrdinalIgnoreCase)) return "India";
+
+        if (cleanSymbol.Contains('.')) return "International";
+
+        return "United States";
     }
 }


### PR DESCRIPTION
## Summary

Closes #50. Consolidates PRs #56, #57, #58, #59, #60, and #61 into a single clean implementation.

> **Review tag**: `browmi03bot`

---

## What changed

Replaced the hardcoded `Country = "US"` pattern (merged in PRs #53/#54) with a `private static string InferCountryFromSymbol(string ticker)` helper added to **AlpacaProvider**, **AlphaVantageProvider**, and **FinnhubProvider**.

### Supported ticker suffixes

| Suffix(es) | Country |
|---|---|
| `.TO`, `.V`, `.CN` | Canada |
| `.L`, `.IL` | United Kingdom |
| `.AX` | Australia |
| `.NZ` | New Zealand |
| `.DE`, `.F` | Germany |
| `.PA` | France |
| `.AS` | Netherlands |
| `.SW` | Switzerland |
| `.BR`, `.SA` | Brazil |
| `.HK` | Hong Kong |
| `.T` | Japan |
| `.KS`, `.KQ` | South Korea |
| `.SS`, `.SZ` | China |
| `.BO`, `.NS` | India |
| (other dotted) | International |
| (no dot) | United States |

### Additional changes
- `MapHistoricalPrices()` in all three providers updated to accept a `ticker` parameter so historical price rows carry the inferred country
- Handles `^` index prefix stripping (e.g., `^GSPC` → `GSPC`)
- All checks use `StringComparison.OrdinalIgnoreCase`

---

## PR comparison

| PR | Approach | Status |
|----|----------|--------|
| #56 | Client-level inference, 2-letter codes | Superseded — inference moved to provider level |
| #57 | Provider-level, full names, 3 providers | Merged into this PR |
| #58 | Switch-based, 4 providers including Yahoo | Merged into this PR; Yahoo skipped (delegates to client) |
| #59 | Hardcode `"US"` everywhere | Superseded by smart inference |
| #60 | Nullable `string? Country = null` in models | Model changes already in `main` via PR #64 |
| **#61** | **Best `InferCountryFromSymbol` — OrdinalIgnoreCase, `^` prefix, "International" fallback** | **Base implementation used here** |

---

## Test results

```
Passed! - Failed: 0, Passed: 379 - StockData.Net.Tests
Passed! - Failed: 0, Passed: 125 - StockData.Net.McpServer.Tests
```

504 / 504 unit tests pass. 0 build warnings.